### PR TITLE
Suppress transport errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ The following keyword args may be passed to ``wrap_riemann``:
 * ``client``: instance of ``bernhard.Client`` to send events with
 * ``tags``: tags to attach to riemann events
 * ``host``: override hostname for the event
+* ``logger``: a standard python logger to which transport errors may be logged
 
 Alternately, a new wrapping function can be created by calling
 ``riemann_wrapper`` like-so::
@@ -60,6 +61,8 @@ The following keyword args may be passed to ``riemann_wrapper``:
 * ``client``: instance of ``bernhard.Client`` to send events with
 * ``global_tags``: tags present in all sent events. Default: ``['python']``.
 * ``host``: override hostname for all events. Default: ``None``.
+* ``logger``: a standard python logger to which transport errors may be logged.
+  Default: ``None``.
 * ``prefix``: prepend given string to all event services. Default: ``python``.
 * ``exception_state``: state sent for exceptions. Default: ``'warning'``.
 * ``send_exceptions``: boolean or callable that takes an exceptions as a

--- a/riemann_wrapper/__init__.py
+++ b/riemann_wrapper/__init__.py
@@ -24,6 +24,9 @@ def riemann_wrapper(client=bernhard.Client(),
 
         tags = global_tags + tags
 
+        def send(event):
+            client.send(event)
+
         def riemann_decorator(f):
             @wraps(f)
             def decorated_function(*args, **kwargs):
@@ -41,22 +44,22 @@ def riemann_wrapper(client=bernhard.Client(),
                 except Exception as e:
 
                     if client and _call_if_callable(send_exceptions):
-                        client.send({'host': hostname,
-                                     'service': metric_name + "-exceptions",
-                                     'description': str(e),
-                                     'tags': tags + ['exception'],
-                                     'attributes': {'prefix': prefix},
-                                     'state': exception_state,
-                                     'metric': 1})
+                        send({'host': hostname,
+                              'service': metric_name + "-exceptions",
+                              'description': str(e),
+                              'tags': tags + ['exception'],
+                              'attributes': {'prefix': prefix},
+                              'state': exception_state,
+                              'metric': 1})
                     raise
 
                 duration = (time.time() - started) * 1000
                 if client:
-                    client.send({'host': hostname,
-                                 'service': metric_name + "-time",
-                                 'attributes': {'prefix': prefix},
-                                 'tags': tags + ['duration'],
-                                 'metric': duration})
+                    send({'host': hostname,
+                          'service': metric_name + "-time",
+                          'attributes': {'prefix': prefix},
+                          'tags': tags + ['duration'],
+                          'metric': duration})
                 return response
             return decorated_function
         return riemann_decorator

--- a/riemann_wrapper/__init__.py
+++ b/riemann_wrapper/__init__.py
@@ -25,7 +25,8 @@ def riemann_wrapper(client=bernhard.Client(),
         tags = global_tags + tags
 
         def send(event):
-            client.send(event)
+            if client:
+                client.send(event)
 
         def riemann_decorator(f):
             @wraps(f)
@@ -43,7 +44,7 @@ def riemann_wrapper(client=bernhard.Client(),
                     response = f(*args, **kwargs)
                 except Exception as e:
 
-                    if client and _call_if_callable(send_exceptions):
+                    if _call_if_callable(send_exceptions):
                         send({'host': hostname,
                               'service': metric_name + "-exceptions",
                               'description': str(e),
@@ -54,12 +55,11 @@ def riemann_wrapper(client=bernhard.Client(),
                     raise
 
                 duration = (time.time() - started) * 1000
-                if client:
-                    send({'host': hostname,
-                          'service': metric_name + "-time",
-                          'attributes': {'prefix': prefix},
-                          'tags': tags + ['duration'],
-                          'metric': duration})
+                send({'host': hostname,
+                      'service': metric_name + "-time",
+                      'attributes': {'prefix': prefix},
+                      'tags': tags + ['duration'],
+                      'metric': duration})
                 return response
             return decorated_function
         return riemann_decorator

--- a/riemann_wrapper/__init__.py
+++ b/riemann_wrapper/__init__.py
@@ -40,10 +40,7 @@ def riemann_wrapper(client=bernhard.Client(),
                     response = f(*args, **kwargs)
                 except Exception as e:
 
-                    if client and send_exceptions:
-                        if callable(send_exceptions):
-                            if not send_exceptions(e):
-                                raise
+                    if client and _call_if_callable(send_exceptions):
                         client.send({'host': hostname,
                                      'service': metric_name + "-exceptions",
                                      'description': str(e),
@@ -68,3 +65,7 @@ def riemann_wrapper(client=bernhard.Client(),
 
 # default riemann wrapper
 wrap_riemann = riemann_wrapper()
+
+
+def _call_if_callable(x):
+    return x() if callable(x) else x


### PR DESCRIPTION
You probably don't want your application to stop working when the Riemann server is down, so this changes the decorator such that it catches `bernhard.TransportError`.

It could be problematic to completely silence the exception if you need it to detect misconfiguration, so I'm also adding an optional `logger` parameter. It accepts a standard Python logger and is used to log the swallowed exceptions.

Commit 2364604 introduces the change; the others are small refactors in support of it.